### PR TITLE
RTE config: Disable "paste-default" edit feature and switch default paste mode to "wordhtml".

### DIFF
--- a/bundles/core/src/main/webapp/app-root/components/teaser/v1/teaser.json
+++ b/bundles/core/src/main/webapp/app-root/components/teaser/v1/teaser.json
@@ -153,7 +153,8 @@
                                   ]
                                 },
                                 "edit": {
-                                  "features": "*",
+                                  "features": ["cut","copy","paste-plaintext","paste-wordhtml"],
+                                  "defaultPasteMode": "wordhtml",
                                   "htmlPasteRules": {
                                     "allowedAttributes": {
                                       "a": [

--- a/bundles/core/src/main/webapp/app-root/components/teaser/v2/teaser.json
+++ b/bundles/core/src/main/webapp/app-root/components/teaser/v2/teaser.json
@@ -142,7 +142,8 @@
                                   ]
                                 },
                                 "edit": {
-                                  "features": "*",
+                                  "features": ["cut","copy","paste-plaintext","paste-wordhtml"],
+                                  "defaultPasteMode": "wordhtml",
                                   "htmlPasteRules": {
                                     "allowedAttributes": {
                                       "a": [

--- a/bundles/core/src/main/webapp/app-root/components/text/v2/text.json
+++ b/bundles/core/src/main/webapp/app-root/components/text/v2/text.json
@@ -63,7 +63,8 @@
                               ]
                             },
                             "edit": {
-                              "features": "*",
+                              "features": ["cut","copy","paste-plaintext","paste-wordhtml"],
+                              "defaultPasteMode": "wordhtml",
                               "htmlPasteRules": {
                                 "allowedAttributes": {
                                   "a": [
@@ -299,7 +300,8 @@
             }
           },
           "edit": {
-            "features": "*",
+            "features": ["cut","copy","paste-plaintext","paste-wordhtml"],
+            "defaultPasteMode": "wordhtml",
             "htmlPasteRules": {
               "allowedAttributes": {
                 "a": [

--- a/changes.xml
+++ b/changes.xml
@@ -27,6 +27,9 @@
       <action type="update" dev="sseifert">
         Switch to AEM 6.5 as minimum version.
       </action>
+      <action type="update" dev="sseifert">
+        RTE config: Disable "paste-default" edit feature (discouraged because it is browser-dependent) and switch default paste mode to "wordhtml".
+      </action>
     </release>
 
     <release version="1.9.2-2.17.12" date="2021-11-08">


### PR DESCRIPTION
"paste-default" is discouraged because it is browser-dependent