### PR TITLE
Fix detection of teaser actions in Teaser V2

### DIFF
--- a/bundles/core/src/main/java/io/wcm/wcm/core/components/impl/models/v1/TeaserV1Impl.java
+++ b/bundles/core/src/main/java/io/wcm/wcm/core/components/impl/models/v1/TeaserV1Impl.java
@@ -83,4 +83,9 @@ public class TeaserV1Impl extends TeaserV2Impl implements LinkMixin {
         getId(), getParentComponent(), this.resource);
   }
 
+  @Override
+  protected boolean getActionsEnabledDefault() {
+    return false;
+  }
+
 }

--- a/bundles/core/src/main/java/io/wcm/wcm/core/components/impl/models/v2/TeaserV2Impl.java
+++ b/bundles/core/src/main/java/io/wcm/wcm/core/components/impl/models/v2/TeaserV2Impl.java
@@ -118,7 +118,7 @@ public class TeaserV2Impl extends AbstractComponentImpl implements Teaser, Media
     boolean actionsDisabled = currentStyle.get(PN_ACTIONS_DISABLED, false);
 
     // read component properties
-    actionsEnabled = properties.get(PN_ACTIONS_ENABLED, false) && !actionsDisabled;
+    actionsEnabled = properties.get(PN_ACTIONS_ENABLED, getActionsEnabledDefault()) && !actionsDisabled;
     boolean titleFromPage = properties.get(PN_TITLE_FROM_PAGE, false);
     boolean descriptionFromPage = properties.get(PN_DESCRIPTION_FROM_PAGE, false);
 
@@ -138,11 +138,13 @@ public class TeaserV2Impl extends AbstractComponentImpl implements Teaser, Media
           }
         }
       }
-      // primary link is not enabled when actions are enabled
-      link = new LinkWrapper(linkHandler.invalid());
     }
 
-    // if no actions enabled, resolve primary teaser link
+    // if actions are enabled and present, primary link is not enabled
+    if (actionsEnabled && !this.actions.isEmpty()) {
+      link = new LinkWrapper(linkHandler.invalid());
+    }
+    // otherwise resolve primary teaser link
     else {
       link = new LinkWrapper(HandlerUnwrapper.get(linkHandler, resource).build());
       targetPage = link.getLinkObject().getTargetPage();
@@ -183,6 +185,10 @@ public class TeaserV2Impl extends AbstractComponentImpl implements Teaser, Media
       }
     }
 
+  }
+
+  protected boolean getActionsEnabledDefault() {
+    return true;
   }
 
   @Override

--- a/bundles/core/src/test/java/io/wcm/wcm/core/components/impl/models/v2/TeaserV2ImplTest.java
+++ b/bundles/core/src/test/java/io/wcm/wcm/core/components/impl/models/v2/TeaserV2ImplTest.java
@@ -24,7 +24,6 @@ import static com.adobe.cq.wcm.core.components.models.Image.PN_IMAGE_FROM_PAGE_I
 import static com.adobe.cq.wcm.core.components.models.Page.NN_PAGE_FEATURED_IMAGE;
 import static com.adobe.cq.wcm.core.components.models.Teaser.NN_ACTIONS;
 import static com.adobe.cq.wcm.core.components.models.Teaser.PN_ACTIONS_DISABLED;
-import static com.adobe.cq.wcm.core.components.models.Teaser.PN_ACTIONS_ENABLED;
 import static com.adobe.cq.wcm.core.components.models.Teaser.PN_ACTION_TEXT;
 import static com.adobe.cq.wcm.core.components.models.Teaser.PN_DESCRIPTION_FROM_PAGE;
 import static com.adobe.cq.wcm.core.components.models.Teaser.PN_DESCRIPTION_HIDDEN;
@@ -109,7 +108,7 @@ class TeaserV2ImplTest {
 
     Teaser underTest = AdaptTo.notNull(context.request(), Teaser.class);
 
-    assertFalse(underTest.isActionsEnabled());
+    assertTrue(underTest.isActionsEnabled());
     assertTrue(underTest.getActions().isEmpty());
     assertFalse(underTest.isImageLinkHidden());
     assertNull(underTest.getTitle());
@@ -125,7 +124,6 @@ class TeaserV2ImplTest {
   }
 
   @Test
-  @SuppressWarnings("null")
   void testWithImageAndPrimaryLink() {
     enableDataLayer(context, true);
 
@@ -140,7 +138,7 @@ class TeaserV2ImplTest {
 
     Teaser underTest = AdaptTo.notNull(context.request(), Teaser.class);
 
-    assertFalse(underTest.isActionsEnabled());
+    assertTrue(underTest.isActionsEnabled());
     assertTrue(underTest.getActions().isEmpty());
     assertFalse(underTest.isImageLinkHidden());
     assertEquals("Teaser Title", underTest.getTitle());
@@ -261,8 +259,7 @@ class TeaserV2ImplTest {
     Resource resource = context.create().resource(page, "teaser",
         PROPERTY_RESOURCE_TYPE, RESOURCE_TYPE,
         PN_LINK_TYPE, ExternalLinkType.ID,
-        PN_LINK_EXTERNAL_REF, "http://host",
-        PN_ACTIONS_ENABLED, true);
+        PN_LINK_EXTERNAL_REF, "http://host");
     context.currentResource(resource);
     context.create().resource(resource, NN_ACTIONS + "/action1",
         PN_ACTION_TEXT, "Action 1",
@@ -297,8 +294,7 @@ class TeaserV2ImplTest {
     Resource resource = context.create().resource(page, "teaser",
         PROPERTY_RESOURCE_TYPE, RESOURCE_TYPE,
         PN_LINK_TYPE, ExternalLinkType.ID,
-        PN_LINK_EXTERNAL_REF, "http://host",
-        PN_ACTIONS_ENABLED, true);
+        PN_LINK_EXTERNAL_REF, "http://host");
     context.currentResource(resource);
     context.create().resource(resource, NN_ACTIONS + "/action1",
         PN_ACTION_TEXT, "Action 1",
@@ -322,7 +318,6 @@ class TeaserV2ImplTest {
         PN_MEDIA_REF_STANDARD, asset.getPath());
     Resource resource = context.create().resource(page, "teaser",
         PROPERTY_RESOURCE_TYPE, RESOURCE_TYPE,
-        PN_ACTIONS_ENABLED, true,
         PN_TITLE_FROM_PAGE, true,
         PN_DESCRIPTION_FROM_PAGE, true,
         PN_IMAGE_FROM_PAGE_IMAGE, true,

--- a/changes.xml
+++ b/changes.xml
@@ -24,7 +24,7 @@
   <body>
 
     <release version="1.13.2-2.22.6" date="not released">
-      <action type="fix" dev="sseifert">
+      <action type="fix" dev="sseifert" issue="12">
         Fix detection of teaser actions in Teaser V2.
       </action>
     </release>

--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.13.2-2.22.6" date="not released">
+      <action type="fix" dev="sseifert">
+        Fix detection of teaser actions in Teaser V2.
+      </action>
+    </release>
+
     <release version="1.13.0-2.22.6" date="2023-05-19">
       <action type="add" dev="sseifert" issue="11">
         Add List (v4).


### PR DESCRIPTION
In Teaser V2, the the property `actionsEnabled` is no longer set explicitly in the teaser dialog. If actions are present, the actions should be enabled.