### PR TITLE
ComponentFeatureImageResolver: Use component resource path for wrapped feature image resource to be able to apply content policies

### DIFF
--- a/bundles/core/src/main/java/io/wcm/wcm/core/components/impl/models/helpers/PageListItemV4Impl.java
+++ b/bundles/core/src/main/java/io/wcm/wcm/core/components/impl/models/helpers/PageListItemV4Impl.java
@@ -192,7 +192,8 @@ public class PageListItemV4Impl extends AbstractListItemImpl implements ListItem
       overriddenProperties.put(PN_LINK_CONTENT_REF, this.getPath());
     }
 
-    return new CoreResourceWrapper(resourceToBeWrapped, delegateResourceType, overriddenProperties, hiddenProperties);
+    return new CoreResourceWrapper(resourceToBeWrapped, resourceToBeWrapped.getPath(),
+        delegateResourceType, overriddenProperties, hiddenProperties);
   }
 
   @JsonIgnore

--- a/bundles/core/src/main/java/io/wcm/wcm/core/components/impl/util/ComponentFeatureImageResolver.java
+++ b/bundles/core/src/main/java/io/wcm/wcm/core/components/impl/util/ComponentFeatureImageResolver.java
@@ -160,7 +160,10 @@ public class ComponentFeatureImageResolver {
     if (resource == null) {
       return null;
     }
-    return new CoreResourceWrapper(resource, HandlerUnwrapper.getResourceType(componentResource));
+    return new CoreResourceWrapper(resource,
+        // use path of component resource to get policy mappings for those
+        componentResource.getPath(),
+        HandlerUnwrapper.getResourceType(componentResource));
   }
 
   /**

--- a/bundles/core/src/main/java/io/wcm/wcm/core/components/impl/util/CoreResourceWrapper.java
+++ b/bundles/core/src/main/java/io/wcm/wcm/core/components/impl/util/CoreResourceWrapper.java
@@ -42,26 +42,30 @@ import com.adobe.cq.export.json.ExporterConstants;
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)
 public final class CoreResourceWrapper extends ResourceWrapper {
 
-  private ValueMap valueMap;
-  private String overriddenResourceType;
+  private final String path;
+  private final ValueMap valueMap;
+  private final String overriddenResourceType;
 
   /**
    * @param resource Target resource
+   * @param path Path of wrapped resource
    * @param overriddenResourceType New resource type
    */
-  public CoreResourceWrapper(@NotNull Resource resource, @NotNull String overriddenResourceType) {
-    this(resource, overriddenResourceType, null, null);
+  public CoreResourceWrapper(@NotNull Resource resource, @NotNull String path, @NotNull String overriddenResourceType) {
+    this(resource, path, overriddenResourceType, null, null);
   }
 
   /**
    * @param resource Target resource
+   * @param path Path of wrapped resource
    * @param overriddenResourceType New resource type
    * @param overriddenProperties Properties to add/overwrite in value map
    * @param hiddenProperties Properties to hide from value map
    */
-  public CoreResourceWrapper(@NotNull Resource resource, @NotNull String overriddenResourceType,
+  public CoreResourceWrapper(@NotNull Resource resource, @NotNull String path, @NotNull String overriddenResourceType,
       @Nullable Map<String, Object> overriddenProperties, @Nullable Set<String> hiddenProperties) {
     super(resource);
+    this.path = path;
     if (StringUtils.isEmpty(overriddenResourceType)) {
       throw new IllegalArgumentException("The " + CoreResourceWrapper.class.getName() + " needs to override the resource type of " +
           "the wrapped resource, but the resourceType argument was null or empty.");
@@ -75,6 +79,11 @@ public final class CoreResourceWrapper extends ResourceWrapper {
     if (hiddenProperties != null) {
       hiddenProperties.forEach(valueMap::remove);
     }
+  }
+
+  @Override
+  public String getPath() {
+    return path;
   }
 
   @Override

--- a/bundles/core/src/test/java/io/wcm/wcm/core/components/impl/util/CoreResourceWrapperTest.java
+++ b/bundles/core/src/test/java/io/wcm/wcm/core/components/impl/util/CoreResourceWrapperTest.java
@@ -59,7 +59,9 @@ class CoreResourceWrapperTest {
         "a", 1,
         "b", 2,
         ResourceResolver.PROPERTY_RESOURCE_TYPE, "a/b/c");
-    Resource wrappedResource = new CoreResourceWrapper(resource, "d/e/f");
+    Resource wrappedResource = new CoreResourceWrapper(resource, resource.getPath(), "d/e/f");
+
+    assertEquals(resource.getPath(), wrappedResource.getPath());
 
     Map<String, Object> expectedProperties = new HashMap<>(resource.getValueMap());
     expectedProperties.put(ResourceResolver.PROPERTY_RESOURCE_TYPE, "d/e/f");
@@ -74,7 +76,9 @@ class CoreResourceWrapperTest {
         "a", 1,
         "b", 2,
         ResourceResolver.PROPERTY_RESOURCE_TYPE, "a/b/c");
-    Resource wrappedResource = new CoreResourceWrapper(resource, "d/e/f", null, Set.of("b"));
+    Resource wrappedResource = new CoreResourceWrapper(resource, "/content/test2", "d/e/f", null, Set.of("b"));
+
+    assertEquals("/content/test2", wrappedResource.getPath());
 
     Map<String, Object> expectedProperties = new HashMap<>(resource.getValueMap());
     expectedProperties.put(ResourceResolver.PROPERTY_RESOURCE_TYPE, "d/e/f");
@@ -95,7 +99,7 @@ class CoreResourceWrapperTest {
     Map<String, Object> overriddenProperties = ImmutableValueMap.of(
         "a", "1",
         "b", "2");
-    Resource wrappedResource = new CoreResourceWrapper(resource, "a/b/c", overriddenProperties, null);
+    Resource wrappedResource = new CoreResourceWrapper(resource, resource.getPath(), "a/b/c", overriddenProperties, null);
 
     // isResourceType()
     assertTrue(wrappedResource.isResourceType("a/b/c"));
@@ -113,7 +117,7 @@ class CoreResourceWrapperTest {
   @Test
   @SuppressWarnings("null")
   void testNulls() {
-    assertThrows(IllegalArgumentException.class, () -> new CoreResourceWrapper(null, null));
+    assertThrows(IllegalArgumentException.class, () -> new CoreResourceWrapper(null, null, null));
   }
 
   @Test
@@ -124,7 +128,7 @@ class CoreResourceWrapperTest {
     when(toBeWrapped.getValueMap()).thenReturn(new ValueMapDecorator(Collections.emptyMap()));
     when(toBeWrapped.getResourceResolver()).thenReturn(resourceResolver);
     when(resourceResolver.isResourceType(any(CoreResourceWrapper.class), any(String.class))).thenReturn(true);
-    Resource wrappedResource = new CoreResourceWrapper(toBeWrapped, "a/b/c");
+    Resource wrappedResource = new CoreResourceWrapper(toBeWrapped, toBeWrapped.getPath(), "a/b/c");
     assertTrue(wrappedResource.isResourceType("a/b/c"));
     verify(resourceResolver).isResourceType(wrappedResource, "a/b/c");
   }

--- a/changes.xml
+++ b/changes.xml
@@ -28,6 +28,9 @@
       <action type="fix" dev="sseifert" issue="35">
         ComponentFeatureImageResolver: If imageFromPageImage is explicitly set to false, do not fallback to image from page if no reference given in component.
       </action>
+      <action type="fix" dev="sseifert">
+        ComponentFeatureImageResolver: Use component resource path for wrapped feature image resource to be able to apply content policies.
+      </action>
     </release>
 
     <release version="2.0.4-2.25.4" date="2024-06-04">

--- a/changes.xml
+++ b/changes.xml
@@ -28,7 +28,7 @@
       <action type="fix" dev="sseifert" issue="35">
         ComponentFeatureImageResolver: If imageFromPageImage is explicitly set to false, do not fallback to image from page if no reference given in component.
       </action>
-      <action type="fix" dev="sseifert">
+      <action type="fix" dev="sseifert" issue="37">
         ComponentFeatureImageResolver: Use component resource path for wrapped feature image resource to be able to apply content policies.
       </action>
     </release>


### PR DESCRIPTION
Fixes #34 