### PR TITLE
wcm.io Image (v3), wcm.io Responsive Image (v1): Fix "Inherit image from page" handling

### DIFF
--- a/bundles/core/src/main/java/io/wcm/wcm/core/components/impl/util/ComponentFeatureImageResolver.java
+++ b/bundles/core/src/main/java/io/wcm/wcm/core/components/impl/util/ComponentFeatureImageResolver.java
@@ -123,10 +123,10 @@ public class ComponentFeatureImageResolver {
     Media media = mediaHandler.invalid();
 
     boolean useImageFromPageImage = imageFromPageImage != null && imageFromPageImage;
-    if (imageFromPageImage == null) {
+    if (!useImageFromPageImage) {
       // image from resource properties
       media = buildMedia(componentResource);
-      if (!media.isValid() && media.getMediaInvalidReason() == MediaInvalidReason.MEDIA_REFERENCE_MISSING) {
+      if (!media.isValid() && media.getMediaInvalidReason() == MediaInvalidReason.MEDIA_REFERENCE_MISSING && imageFromPageImage == null) {
         // fallback to image from page if no reference was given and imageFromPageImage is neither enabled nor disabled
         useImageFromPageImage = true;
       }

--- a/bundles/core/src/main/java/io/wcm/wcm/core/components/impl/util/ComponentFeatureImageResolver.java
+++ b/bundles/core/src/main/java/io/wcm/wcm/core/components/impl/util/ComponentFeatureImageResolver.java
@@ -42,7 +42,6 @@ import com.day.cq.wcm.api.designer.Style;
 import io.wcm.handler.media.Media;
 import io.wcm.handler.media.MediaBuilder;
 import io.wcm.handler.media.MediaHandler;
-import io.wcm.handler.media.MediaInvalidReason;
 
 /**
  * Resolves images and alt. texts for components either from the component resource,
@@ -56,7 +55,7 @@ public class ComponentFeatureImageResolver {
   private final MediaHandler mediaHandler;
   private final Map<String, Object> mediaHandlerProperties = new HashMap<>();
 
-  private final Boolean imageFromPageImage;
+  private final boolean imageFromPageImage;
   private final boolean altValueFromPageImage;
   private boolean altValueFromDam;
   private final boolean isDecorative;
@@ -78,7 +77,7 @@ public class ComponentFeatureImageResolver {
 
     // component properties
     ValueMap props = componentResource.getValueMap();
-    this.imageFromPageImage = props.get(PN_IMAGE_FROM_PAGE_IMAGE, Boolean.class);
+    this.imageFromPageImage = props.get(PN_IMAGE_FROM_PAGE_IMAGE, false);
     this.altValueFromPageImage = props.get(PN_ALT_VALUE_FROM_PAGE_IMAGE, false);
     this.altValueFromDam = props.get(PN_ALT_VALUE_FROM_DAM, false);
     this.isDecorative = props.get(PN_IS_DECORATIVE, currentStyle.get(PN_IS_DECORATIVE, false));
@@ -122,17 +121,12 @@ public class ComponentFeatureImageResolver {
   public @NotNull Media buildMedia() {
     Media media = mediaHandler.invalid();
 
-    boolean useImageFromPageImage = imageFromPageImage != null && imageFromPageImage;
-    if (!useImageFromPageImage) {
+    if (!imageFromPageImage) {
       // image from resource properties
       media = buildMedia(componentResource);
-      if (!media.isValid() && media.getMediaInvalidReason() == MediaInvalidReason.MEDIA_REFERENCE_MISSING && imageFromPageImage == null) {
-        // fallback to image from page if no reference was given and imageFromPageImage is neither enabled nor disabled
-        useImageFromPageImage = true;
-      }
     }
 
-    if (useImageFromPageImage) {
+    if (imageFromPageImage) {
       // try to get feature image from target page
       if (targetPage != null) {
         Resource featuredImageResource = ComponentUtils.getFeaturedImage(targetPage);

--- a/bundles/core/src/main/webapp/app-root/components/image/v3/README.md
+++ b/bundles/core/src/main/webapp/app-root/components/image/v3/README.md
@@ -18,6 +18,7 @@ wcm-io/wcm/core/components/image/v3/image
 * Uses the enhanced Media Handler File Upload dialog widget with path field and media format validation
 * Uses [wcm.io Link Handler][wcmio-handler-link] for processing the image link
 * Uses the Link Handler dialog widget for defining link type and link target
+* The feature "Inherit featured image from page" is disabled by default for a new component, but can be enabled in the edit dialog
 
 
 [extends-component]: https://github.com/adobe/aem-core-wcm-components/tree/master/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image

--- a/bundles/core/src/test/java/io/wcm/wcm/core/components/impl/models/v3/ImageV3ImplTest.java
+++ b/bundles/core/src/test/java/io/wcm/wcm/core/components/impl/models/v3/ImageV3ImplTest.java
@@ -23,6 +23,7 @@ import static com.adobe.cq.wcm.core.components.models.Image.PN_ALT_VALUE_FROM_DA
 import static com.adobe.cq.wcm.core.components.models.Image.PN_DESIGN_LAZY_LOADING_ENABLED;
 import static com.adobe.cq.wcm.core.components.models.Image.PN_DESIGN_LAZY_THRESHOLD;
 import static com.adobe.cq.wcm.core.components.models.Image.PN_DISPLAY_POPUP_TITLE;
+import static com.adobe.cq.wcm.core.components.models.Image.PN_IMAGE_FROM_PAGE_IMAGE;
 import static com.adobe.cq.wcm.core.components.models.Image.PN_IS_DECORATIVE;
 import static com.adobe.cq.wcm.core.components.models.Image.PN_MAP;
 import static com.adobe.cq.wcm.core.components.models.Image.PN_TITLE_VALUE_FROM_DAM;
@@ -212,7 +213,8 @@ class ImageV3ImplTest {
     context.currentResource(context.create().resource(page1, "image",
         PROPERTY_RESOURCE_TYPE, RESOURCE_TYPE,
         JCR_TITLE, "Resource Title",
-        PN_ALT, "Resource Alt"));
+        PN_ALT, "Resource Alt",
+        PN_IMAGE_FROM_PAGE_IMAGE, true));
 
     Image underTest = AdaptTo.notNull(context.request(), Image.class);
 

--- a/bundles/core/src/test/java/io/wcm/wcm/core/components/impl/util/ComponentFeatureImageResolverTest.java
+++ b/bundles/core/src/test/java/io/wcm/wcm/core/components/impl/util/ComponentFeatureImageResolverTest.java
@@ -121,6 +121,23 @@ class ComponentFeatureImageResolverTest {
 
   @Test
   @SuppressWarnings("null")
+  void testComponentImage_ComponentImageFromPage_Disabled() {
+    Resource component = context.create().resource(page1, "comp1",
+        PROPERTY_RESOURCE_TYPE, COMPONENT_RESOURCE_TYPE,
+        PN_MEDIA_REF_STANDARD, asset1.getPath(),
+        PN_MEDIA_ALTTEXT_STANDARD, "My Alt",
+        PN_IMAGE_FROM_PAGE_IMAGE, false);
+
+    Media media = newComponentFeatureImageResolver(component)
+      .buildMedia();
+
+    assertTrue(media.isValid());
+    assertEquals("/content/dam/sample/sample1.jpg/_jcr_content/renditions/original.image_file.160.90.0,35,160,125.file/sample1.jpg", media.getUrl());
+    assertEquals("My Alt", media.getAsset().getAltText());
+  }
+
+  @Test
+  @SuppressWarnings("null")
   void testComponentImage_Decorative() {
     Resource component = context.create().resource(page1, "comp1",
         PROPERTY_RESOURCE_TYPE, COMPONENT_RESOURCE_TYPE,
@@ -212,7 +229,6 @@ class ComponentFeatureImageResolverTest {
   void testComponentImageFromPage_Disabled() {
     Resource component = context.create().resource(page1, "comp1",
         PROPERTY_RESOURCE_TYPE, COMPONENT_RESOURCE_TYPE,
-        PN_MEDIA_REF_STANDARD, asset1.getPath(),
         PN_MEDIA_ALTTEXT_STANDARD, "My Alt",
         PN_IMAGE_FROM_PAGE_IMAGE, false,
         PN_ALT_VALUE_FROM_PAGE_IMAGE, true);

--- a/changes.xml
+++ b/changes.xml
@@ -28,6 +28,9 @@
       <action type="update" dev="sseifert">
         Switch to AEM 6.5.24 as minimum version (also compatible with AEM 6.6.2 / AEM 6.5 LTS SP2 and AEMaaCS).
       </action>
+      <action type="fix" dev="sseifert" issue="88">
+        wcm.io Image (v3): Render image defined in component when "Inherit image from page" is explicitly disabled.
+      </action>
     </release>
 
     <release version="2.0.10-2.25.4" date="2026-02-24">

--- a/changes.xml
+++ b/changes.xml
@@ -29,7 +29,7 @@
         Switch to AEM 6.5.24 as minimum version (also compatible with AEM 6.6.2 / AEM 6.5 LTS SP2 and AEMaaCS).
       </action>
       <action type="fix" dev="sseifert" issue="88">
-        wcm.io Image (v3): Render image defined in component when "Inherit image from page" is explicitly disabled.
+        wcm.io Image (v3), wcm.io Responsive Image (v1): Fix "Inherit image from page" handling.
       </action>
     </release>
 


### PR DESCRIPTION
Fix a regression introduced in #35, and the default behavior of the "Inherit image from page" feature handling.

* when "Image (v3)" component was introduced in 2023, the feature "Inherit image from page" was configured as not enabled by default in the edit dialog
* at the same time, ComponentFeatureImageResolver was implemented with a special fallback mode, that automatically displayed the page feature image, when no image was defined for the component, and imageFromPageImage was null in repository - in that case, the page feature image was displayed, although it was not disabled as enabled in the edit dialog.
* with #35 this behavior was changed to render the actual component image only, if imageFromPageImage was null in repository - to avoid an invalid fallback. however, this has the issue that the component image is not rendered at all, when a valid reference is present and imageFromPageImage is "false" in the respository.

This PR simplifies and fixed the behavior:
* imageFromPageImage=false and imageFromPageImage=null is treated the same - the component image is rendered
* the page feature page is only rendered if imageFromPageImage=true, and not in all other cases (no default magic when the property is null)