### PR TITLE
Image (v3), Teaser (v2), Responsive Image (v1): Fix "Inherit image from page" behavior

### DIFF
--- a/bundles/core/src/main/java/io/wcm/wcm/core/components/impl/util/ComponentFeatureImageResolver.java
+++ b/bundles/core/src/main/java/io/wcm/wcm/core/components/impl/util/ComponentFeatureImageResolver.java
@@ -120,7 +120,7 @@ public class ComponentFeatureImageResolver {
    * @return Media
    */
   public @NotNull Media buildMedia() {
-    Media media = mediaHandler.invalid();
+    Media media;
 
     // special handling if imageFromPageImage is not set at all - check if image from resource is valid, otherwise fallback to image from page.
     boolean useImageFromPageImage = imageFromPageImage != null && imageFromPageImage;

--- a/bundles/core/src/main/java/io/wcm/wcm/core/components/impl/util/ComponentFeatureImageResolver.java
+++ b/bundles/core/src/main/java/io/wcm/wcm/core/components/impl/util/ComponentFeatureImageResolver.java
@@ -147,11 +147,9 @@ public class ComponentFeatureImageResolver {
       }
     }
 
-    else {
+    else if (media == null) {
       // image from resource properties, if not build already
-      if (media == null) {
-        media = buildMedia(componentResource);
-      }
+      media = buildMedia(componentResource);
     }
 
     return media;

--- a/bundles/core/src/main/java/io/wcm/wcm/core/components/impl/util/ComponentFeatureImageResolver.java
+++ b/bundles/core/src/main/java/io/wcm/wcm/core/components/impl/util/ComponentFeatureImageResolver.java
@@ -122,7 +122,7 @@ public class ComponentFeatureImageResolver {
   public @NotNull Media buildMedia() {
     Media media = null;
 
-    // special handling if imageFromPageImage is not set at all - check if image from resource is valid, otherwise fallback to image from page.
+    // special handling when imageFromPageImage is not set: use the image from the resource if valid; fallback to the page featured image only if no media reference was provided.
     boolean useImageFromPageImage = imageFromPageImage != null && imageFromPageImage;
     if (imageFromPageImage == null) {
       media = buildMedia(componentResource);

--- a/bundles/core/src/main/java/io/wcm/wcm/core/components/impl/util/ComponentFeatureImageResolver.java
+++ b/bundles/core/src/main/java/io/wcm/wcm/core/components/impl/util/ComponentFeatureImageResolver.java
@@ -122,12 +122,11 @@ public class ComponentFeatureImageResolver {
   public @NotNull Media buildMedia() {
     Media media = mediaHandler.invalid();
 
+    // special handling if imageFromPageImage is not set at all - check if image from resource is valid, otherwise fallback to image from page.
     boolean useImageFromPageImage = imageFromPageImage != null && imageFromPageImage;
     if (imageFromPageImage == null) {
-      // image from resource properties
       media = buildMedia(componentResource);
       if (!media.isValid() && media.getMediaInvalidReason() == MediaInvalidReason.MEDIA_REFERENCE_MISSING) {
-        // fallback to image from page if no reference was given and imageFromPageImage is neither enabled nor disabled
         useImageFromPageImage = true;
       }
     }
@@ -146,6 +145,11 @@ public class ComponentFeatureImageResolver {
         Resource featuredImageResource = ComponentUtils.getFeaturedImage(currentPage);
         media = buildMedia(wrapFeatureImageResource(featuredImageResource));
       }
+    }
+
+    else {
+      // image from resource properties
+      media = buildMedia(componentResource);
     }
 
     return media;

--- a/bundles/core/src/main/java/io/wcm/wcm/core/components/impl/util/ComponentFeatureImageResolver.java
+++ b/bundles/core/src/main/java/io/wcm/wcm/core/components/impl/util/ComponentFeatureImageResolver.java
@@ -120,7 +120,7 @@ public class ComponentFeatureImageResolver {
    * @return Media
    */
   public @NotNull Media buildMedia() {
-    Media media;
+    Media media = null;
 
     // special handling if imageFromPageImage is not set at all - check if image from resource is valid, otherwise fallback to image from page.
     boolean useImageFromPageImage = imageFromPageImage != null && imageFromPageImage;
@@ -148,8 +148,10 @@ public class ComponentFeatureImageResolver {
     }
 
     else {
-      // image from resource properties
-      media = buildMedia(componentResource);
+      // image from resource properties, if not build already
+      if (media == null) {
+        media = buildMedia(componentResource);
+      }
     }
 
     return media;

--- a/bundles/core/src/main/webapp/app-root/components/image/v3/image.json
+++ b/bundles/core/src/main/webapp/app-root/components/image/v3/image.json
@@ -29,11 +29,14 @@
 
                         /** Overwrite property to apply show/hide behavior for FileUpload widget */
                         "imageFromPageImage": {
-                          "sling:resourceType": "wcm-io/wcm/ui/granite/components/form/checkbox",
+                          "uncheckedValue": "false",
+                          "forceIgnoreFreshness": true,
                           "name": "./imageFromPageImage",
                           "text": "Inherit featured image from page",
-                          "fieldDescription": "Use the featured image defined in the properties of the linked page, or in the properties of the current page when no link is defined.",
+                          "value": true,
                           "checked": "${true}",
+                          "sling:resourceType": "granite/ui/components/coral/foundation/form/checkbox",
+                          "fieldDescription": "Use the featured image defined in the properties of the linked page, or in the properties of the current page when no link is defined.",
                           "granite:class": "wcmio-dialog-showhide",
                           "granite:data": {
                             "wcmio-dialog-showhide-target": ".wcmio-wcm-core-components-mediaalttextinclude-imagefrompageimage"

--- a/bundles/core/src/main/webapp/app-root/components/image/v3/image.json
+++ b/bundles/core/src/main/webapp/app-root/components/image/v3/image.json
@@ -27,6 +27,19 @@
                     "column": {
                       "items": {
 
+                        /** Overwrite property to apply show/hide behavior for FileUpload widget */
+                        "imageFromPageImage": {
+                          "sling:resourceType": "wcm-io/wcm/ui/granite/components/form/checkbox",
+                          "name": "./imageFromPageImage",
+                          "text": "Inherit featured image from page",
+                          "fieldDescription": "Use the featured image defined in the properties of the linked page, or in the properties of the current page when no link is defined.",
+                          "checked": "${true}",
+                          "granite:class": "wcmio-dialog-showhide",
+                          "granite:data": {
+                            "wcmio-dialog-showhide-target": ".wcmio-wcm-core-components-mediaalttextinclude-imagefrompageimage"
+                          }
+                        },
+
                         /* Does not work with media handler */
                         "pageImageThumbnail": {
                           "sling:hideResource": true
@@ -35,6 +48,11 @@
                         /* Use wcm.io Media Handler FileUpload */
                         "file": {
                           "sling:resourceType": "wcm-io/handler/media/components/granite/form/fileupload",
+                          "granite:class": "wcmio-wcm-core-components-mediaalttextinclude-imagefrompageimage",
+                          "granite:data": {
+                            "showhidetargetvalue": "true",
+                            "showhidetargetnot": "true"
+                          },
                           "allowUpload": "${not empty cqDesign.allowUpload ? cqDesign.allowUpload : true}"
                         },
 

--- a/bundles/core/src/main/webapp/app-root/components/image/v3/image.json
+++ b/bundles/core/src/main/webapp/app-root/components/image/v3/image.json
@@ -27,18 +27,6 @@
                     "column": {
                       "items": {
 
-                        /** Overwrite property to switch default value to unchecked */
-                        "imageFromPageImage": {
-                          "uncheckedValue": "false",
-                          "forceIgnoreFreshness": true,
-                          "name": "./imageFromPageImage",
-                          "text": "Inherit featured image from page",
-                          "value": true,
-                          "checked": "${false}",
-                          "sling:resourceType": "granite/ui/components/coral/foundation/form/checkbox",
-                          "fieldDescription": "Use the featured image defined in the properties of the linked page, or in the properties of the current page when no link is defined."
-                        },
-
                         /* Does not work with media handler */
                         "pageImageThumbnail": {
                           "sling:hideResource": true

--- a/bundles/core/src/main/webapp/app-root/components/wcmio/commons/mediaAltTextInclude/v1/mediaAltTextInclude.json
+++ b/bundles/core/src/main/webapp/app-root/components/wcmio/commons/mediaAltTextInclude/v1/mediaAltTextInclude.json
@@ -16,6 +16,7 @@
               "name": "./imageFromPageImage",
               "text": "Inherit featured image from page",
               "fieldDescription": "Use the featured image defined in the properties of the linked page, or in the properties of the current page when no link is defined.",
+              "checked": "${true}",
               "granite:class": "wcmio-dialog-showhide",
               "granite:data": {
                 "wcmio-dialog-showhide-target": ".wcmio-wcm-core-components-mediaalttextinclude-imagefrompageimage"

--- a/bundles/core/src/test/java/io/wcm/wcm/core/components/impl/util/ComponentFeatureImageResolverTest.java
+++ b/bundles/core/src/test/java/io/wcm/wcm/core/components/impl/util/ComponentFeatureImageResolverTest.java
@@ -209,6 +209,7 @@ class ComponentFeatureImageResolverTest {
   }
 
   @Test
+  @SuppressWarnings("null")
   void testComponentImageFromPage_Disabled() {
     Resource component = context.create().resource(page1, "comp1",
         PROPERTY_RESOURCE_TYPE, COMPONENT_RESOURCE_TYPE,
@@ -226,7 +227,9 @@ class ComponentFeatureImageResolverTest {
       .targetPage(page2)
       .buildMedia();
 
-    assertFalse(media.isValid());
+    assertTrue(media.isValid());
+    assertEquals("/content/dam/sample/sample1.jpg/_jcr_content/renditions/original.image_file.160.90.0,35,160,125.file/sample1.jpg", media.getUrl());
+    assertEquals("My Alt", media.getAsset().getAltText());
   }
 
   @Test

--- a/bundles/core/src/test/java/io/wcm/wcm/core/components/impl/util/ComponentFeatureImageResolverTest.java
+++ b/bundles/core/src/test/java/io/wcm/wcm/core/components/impl/util/ComponentFeatureImageResolverTest.java
@@ -278,6 +278,66 @@ class ComponentFeatureImageResolverTest {
     assertFalse(media.isValid());
   }
 
+  @Test
+  @SuppressWarnings("null")
+  void testImageFromPageImageNotSet_NoMediaReference_FallbackToPageImage() {
+    // imageFromPageImage not set + no media reference => fallback to page featured image
+    Resource component = context.create().resource(page1, "comp1",
+        PROPERTY_RESOURCE_TYPE, COMPONENT_RESOURCE_TYPE,
+        PN_ALT_VALUE_FROM_PAGE_IMAGE, true);
+
+    // create feature image in page2
+    context.create().resource(page2, NN_PAGE_FEATURED_IMAGE,
+        PN_MEDIA_REF_STANDARD, asset2.getPath(),
+        PN_MEDIA_ALTTEXT_STANDARD, "Feature Alt");
+
+    Media media = newComponentFeatureImageResolver(component)
+      .targetPage(page2)
+      .buildMedia();
+
+    assertTrue(media.isValid());
+    assertEquals("/content/dam/sample/sample2.jpg/_jcr_content/renditions/original.image_file.160.90.0,35,160,125.file/sample2.jpg", media.getUrl());
+    assertEquals("Feature Alt", media.getAsset().getAltText());
+  }
+
+  @Test
+  void testImageFromPageImageNotSet_InvalidMediaReference_NoFallback() {
+    // imageFromPageImage not set + invalid media reference => no fallback to page featured image
+    Resource component = context.create().resource(page1, "comp1",
+        PROPERTY_RESOURCE_TYPE, COMPONENT_RESOURCE_TYPE,
+        PN_MEDIA_REF_STANDARD, "/content/dam/invalid.jpg");
+
+    // create feature image in page2 - must not be used because media reference is set but invalid
+    context.create().resource(page2, NN_PAGE_FEATURED_IMAGE,
+        PN_MEDIA_REF_STANDARD, asset2.getPath(),
+        PN_MEDIA_ALTTEXT_STANDARD, "Feature Alt");
+
+    Media media = newComponentFeatureImageResolver(component)
+      .targetPage(page2)
+      .buildMedia();
+
+    assertFalse(media.isValid());
+  }
+
+  @Test
+  void testImageFromPageImageDisabled_NoMediaReference_NoFallback() {
+    // imageFromPageImage == false + no media reference => no fallback to page featured image
+    Resource component = context.create().resource(page1, "comp1",
+        PROPERTY_RESOURCE_TYPE, COMPONENT_RESOURCE_TYPE,
+        PN_IMAGE_FROM_PAGE_IMAGE, false);
+
+    // create feature image in page2 - must not be used because feature image is explicitly disabled
+    context.create().resource(page2, NN_PAGE_FEATURED_IMAGE,
+        PN_MEDIA_REF_STANDARD, asset2.getPath(),
+        PN_MEDIA_ALTTEXT_STANDARD, "Feature Alt");
+
+    Media media = newComponentFeatureImageResolver(component)
+      .targetPage(page2)
+      .buildMedia();
+
+    assertFalse(media.isValid());
+  }
+
   @SuppressWarnings("deprecation")
   private ComponentFeatureImageResolver newComponentFeatureImageResolver(@NotNull Resource resource) {
     context.currentResource(resource);

--- a/changes.xml
+++ b/changes.xml
@@ -31,6 +31,11 @@
       <action type="fix" dev="sseifert" issue="92">
         Image (v3): Enabled inheritance for cq:editConfig to ensure cq:dropTargets configuration is applied as well.
       </action>
+      <action type="fix" dev="sseifert" issue="93">
+        Image (v3), Teaser (v2), Responsive Image (v1): Fix "Inherit image from page" behavior.
+        Ensure image from resource properties is rendered when imageFromPageImage = false.
+        Enable "Inherit image from page" checkbox state in component edit dialog by default for new components.
+      </action>
     </release>
 
     <release version="2.0.10-2.25.4" date="2026-02-24">


### PR DESCRIPTION
Fixes #90 

* ensure image from resource properties is rendered when `imageFromPageImage` = `false`
* enable "Inherit image from page" checkbox state in component edit dialog by default for new components
* also fix show/hide behavior in Image (v3) dialog when "Inherit image from page" is checked